### PR TITLE
Change matrix types to float32

### DIFF
--- a/h3d/Matrix.hx
+++ b/h3d/Matrix.hx
@@ -1,5 +1,6 @@
 package h3d;
 import hxd.Math;
+import hxd.impl.Float32;
 
 typedef ColorAdjust = {
 	?saturation : Float,
@@ -14,22 +15,22 @@ class Matrix {
 
 	static var tmp = new Matrix();
 
-	public var _11 : Float;
-	public var _12 : Float;
-	public var _13 : Float;
-	public var _14 : Float;
-	public var _21 : Float;
-	public var _22 : Float;
-	public var _23 : Float;
-	public var _24 : Float;
-	public var _31 : Float;
-	public var _32 : Float;
-	public var _33 : Float;
-	public var _34 : Float;
-	public var _41 : Float;
-	public var _42 : Float;
-	public var _43 : Float;
-	public var _44 : Float;
+	public var _11 : Float32;
+	public var _12 : Float32;
+	public var _13 : Float32;
+	public var _14 : Float32;
+	public var _21 : Float32;
+	public var _22 : Float32;
+	public var _23 : Float32;
+	public var _24 : Float32;
+	public var _31 : Float32;
+	public var _32 : Float32;
+	public var _33 : Float32;
+	public var _34 : Float32;
+	public var _41 : Float32;
+	public var _42 : Float32;
+	public var _43 : Float32;
+	public var _44 : Float32;
 
 	public var tx(get, set) : Float;
 	public var ty(get, set) : Float;

--- a/hxd/impl/Float32.hx
+++ b/hxd/impl/Float32.hx
@@ -1,7 +1,6 @@
 package hxd.impl;
 
-typedef Float32 = 
-#if hl hl.F32 #elseif js __Float32 #else Float #end;
+typedef Float32 = #if hl hl.F32 #elseif js __Float32 #else Float #end;
 
 abstract __Float32(Float) from Float to Float {
 	private static inline final MAX_SAFE_FLOAT = 3.402823466e+38;

--- a/hxd/impl/Float32.hx
+++ b/hxd/impl/Float32.hx
@@ -1,3 +1,86 @@
 package hxd.impl;
 
-typedef Float32 = #if hl hl.F32 #else Float #end;
+typedef Float32 = 
+#if hl hl.F32 #elseif js __Float32 #else Float #end;
+
+abstract __Float32(Float) from Float to Float {
+	private static inline final MAX_SAFE_FLOAT = 3.402823466e+38;
+	private static inline final CLAMP_MIN = -MAX_SAFE_FLOAT;
+	private static inline final CLAMP_MAX = MAX_SAFE_FLOAT;
+
+	private inline function new(v:Float) {
+		this = saturate(v);
+	}
+
+	private static inline function make(v:Float):__Float32 {
+		return new __Float32(v);
+	}
+
+	private static inline function saturate(v:Float):__Float32 {
+		return Math.min(Math.max(v, CLAMP_MIN), CLAMP_MAX);
+	}
+
+	@:op(-A) private inline function negate():__Float32 {
+		return saturate(this * -1);
+	}
+
+	@:op(++A) private inline function preIncrement():__Float32 {
+		return this = saturate(++this);
+	}
+
+	@:op(A++) private inline function postIncrement():__Float32 {
+		var ret = this++;
+		this = saturate(this);
+		return ret;
+	}
+
+	@:op(--A) private inline function preDecrement():__Float32 {
+		return this = saturate(--this);
+	}
+
+	@:op(A--) private inline function postDecrement():__Float32 {
+		var ret = this--;
+		this = saturate(this);
+		return ret;
+	}
+
+	@:op(A * B) private static inline function mul(a:__Float32, b:__Float32):__Float32 {
+		return saturate((a : Float) * (b : Float));
+	}
+
+	@:op(A / B) private static inline function div(a:__Float32, b:__Float32):__Float32{
+		return saturate((a : Float) / (b : Float));
+	}
+
+	@:op(A + B) private static inline function add(a:__Float32, b:__Float32):__Float32 {
+		return saturate((a : Float) + (b : Float));
+	}
+
+	@:op(A - B) private static inline function sub(a:__Float32, b:__Float32):__Float32{
+		return saturate((a : Float) - (b : Float));
+	}
+
+	@:op(A == B) private static function eq(a:__Float32, b:__Float32):Bool{
+		return (a : Float) == (b : Float);
+	}
+
+	@:op(A != B) private static function neq(a:__Float32, b:__Float32):Bool{
+		return (a : Float) != (b : Float);
+	}
+
+	@:op(A < B) private static function lt(a:__Float32, b:__Float32):Bool{
+		return (a : Float) < (b : Float);
+	}
+
+	@:op(A <= B) private static function lte(a:__Float32, b:__Float32):Bool{
+		return (a : Float) <= (b : Float);
+	}  	
+
+	@:op(A > B) private static function gt(a:__Float32, b:__Float32):Bool{
+		return (a : Float) > (b : Float);
+	}
+
+	@:op(A >= B) private static function gte(a:__Float32, b:__Float32):Bool{
+		return (a : Float) >= (b : Float);
+	}
+}


### PR DESCRIPTION
The problem with disappearing textures was that during many animation operations after a long time some values fell into the double precision range, webgl shaders only support single precision. I applied values  saturation and replaced all the variables needed for the shader with Float32.